### PR TITLE
Adds ability to pass middleware to socket server

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,7 @@ const botmaster = new Botmaster();
 const socketioSettings = {
   id: 'SOME_BOT_ID_OF_YOUR_CHOOSING',
   server: botmaster.server, // this is required for socket.io. You can set it to another node server object if you wish to. But in this example, we will use the one created by botmaster under the hood
+  middleware: [] // custom middleware you want to attach to the socket server, such as express-socket.io-session
 };
 
 const socketioBot = new SocketioBot(socketioSettings);

--- a/lib/socket.io_bot.js
+++ b/lib/socket.io_bot.js
@@ -7,13 +7,12 @@ const debug = require('debug')('botmaster:socket.io');
 const merge = require('lodash').merge;
 
 class SocketioBot extends BaseBot {
-
   constructor(settings) {
     super(settings);
     this.type = 'socket.io';
 
     this.__applySettings(settings);
-    this.__setupSocketioServer();
+    this.__setupSocketioServer(settings);
   }
 
   __applySettings(settings) {
@@ -65,8 +64,9 @@ class SocketioBot extends BaseBot {
     };
   }
 
-  __setupSocketioServer() {
+  __setupSocketioServer(settings) {
     this.ioServer = io(this.server);
+    this.__registerSocketMiddleware(this.ioServer, settings.middleware);
 
     this.ioServer.on('connection', (socket) => {
       debug(`new socket connected with id: ${socket.id}`);
@@ -86,6 +86,12 @@ class SocketioBot extends BaseBot {
         const update = this.__formatUpdate(rawUpdate, botmasterUserId);
         return this.__emitUpdate(update);
       });
+    });
+  }
+
+  __registerSocketMiddleware(ioServer, middleware = []) {
+    middleware.forEach(piece => {
+      ioServer.use(piece);
     });
   }
 

--- a/lib/socket.io_bot.js
+++ b/lib/socket.io_bot.js
@@ -12,7 +12,7 @@ class SocketioBot extends BaseBot {
     this.type = 'socket.io';
 
     this.__applySettings(settings);
-    this.__setupSocketioServer(settings);
+    this.__setupSocketioServer(settings.middleware);
   }
 
   __applySettings(settings) {
@@ -64,9 +64,9 @@ class SocketioBot extends BaseBot {
     };
   }
 
-  __setupSocketioServer(settings) {
+  __setupSocketioServer(middleware) {
     this.ioServer = io(this.server);
-    this.__registerSocketMiddleware(this.ioServer, settings.middleware);
+    this.__registerSocketMiddleware(this.ioServer, middleware);
 
     this.ioServer.on('connection', (socket) => {
       debug(`new socket connected with id: ${socket.id}`);

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "eslint-plugin-react": "^6.10.0",
     "jsdoc": "^3.4.2",
     "nyc": "^10.1.2",
-    "request-promise": "^4.1.1"
+    "request-promise": "^4.1.1",
+    "sinon": "^2.4.1"
   }
 }

--- a/tests/constructor.js
+++ b/tests/constructor.js
@@ -1,6 +1,6 @@
 import test from 'ava';
+import sinon from 'sinon';
 import Botmaster from 'botmaster';
-
 import SocketioBot from '../lib';
 
 test('should throw an error when settings does not have an id', (t) => {
@@ -60,6 +60,7 @@ test('passing no receives setting defaults to default receives settings', (t) =>
     },
     echo: false,
     read: false,
+    delivery: true,
     postback: false,
     quickReply: false,
   };
@@ -130,3 +131,15 @@ test('passing no sends setting defaults to default sends settings', (t) => {
     });
   });
 });
+
+test('calls to use the passed middleware for each supplied piece', t => {
+  const botmaster = new Botmaster()
+  const bot = new SocketioBot({ id: 'something', server: botmaster.server });
+  const ioServer = {
+    use: sinon.spy()
+  }
+
+  bot.__registerSocketMiddleware(ioServer, ['test'])
+
+  t.true(ioServer.use.calledOnce)
+})

--- a/tests/constructor.js
+++ b/tests/constructor.js
@@ -132,14 +132,26 @@ test('passing no sends setting defaults to default sends settings', (t) => {
   });
 });
 
-test('calls to use the passed middleware for each supplied piece', t => {
-  const botmaster = new Botmaster()
+test('calls to use the passed middleware for one supplied piece', t => {
+  const botmaster = new Botmaster();
   const bot = new SocketioBot({ id: 'something', server: botmaster.server });
   const ioServer = {
     use: sinon.spy()
-  }
+  };
 
-  bot.__registerSocketMiddleware(ioServer, ['test'])
+  bot.__registerSocketMiddleware(ioServer, ['test']);
 
-  t.true(ioServer.use.calledOnce)
-})
+  t.true(ioServer.use.calledOnce);
+});
+
+test('calls to use the passed middleware for multiple supplied pieces', t => {
+  const botmaster = new Botmaster();
+  const bot = new SocketioBot({ id: 'something', server: botmaster.server });
+  const ioServer = {
+    use: sinon.spy()
+  };
+
+  bot.__registerSocketMiddleware(ioServer, ['test', 'test1', 'test2']);
+
+  t.deepEqual(ioServer.use.callCount, 3);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,6 +1168,10 @@ diff@^3.0.0, diff@^3.0.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
+diff@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
+
 doctrine@1.5.0, doctrine@^1.2.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -1669,6 +1673,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
+  dependencies:
+    samsam "1.x"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2500,6 +2510,10 @@ log-driver@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
 
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -2663,6 +2677,10 @@ mute-stream@0.0.5:
 nan@^2.3.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
+
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -2964,6 +2982,12 @@ path-key@^2.0.0:
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -3380,6 +3404,10 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
+
 semver-diff@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
@@ -3413,6 +3441,19 @@ signal-exit@^2.0.0:
 signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sinon@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.4.1.tgz#021fd64b54cb77d9d2fb0d43cdedfae7629c3a36"
+  dependencies:
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -3673,6 +3714,10 @@ test-exclude@^3.3.0:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -3740,6 +3785,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
Hi all,

On the project I am using this with there is a requirement for session management on our Node server. We tie this in with express-session and Redis. However, to make this session available to us in our Botmaster actions, we must sync it all together with the created socket server. The solution is to provide us with the ability to pass in middleware in the core settings object.

This PR adds the ability to pass your own middleware (as an array, so as many as one pleases) to the ioServer that is created under the hood.

Like in the ReadME tweak, I've added this as the main example I imagine people are likely to require as this framework grows: https://www.npmjs.com/package/express-socket.io-session

If we can please work together to get this PR smoothly merged and published to NPM as soon as possible, it'd be greatly appreciated. I hate having project dependencies on a fork.

Thanks,
Owen 